### PR TITLE
Disable tests at Python build time, as per nocheck option

### DIFF
--- a/debian-pkg/debian/rules
+++ b/debian-pkg/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 DEB_BUILD_OPTIONS = nocheck
+export PYBUILD_DISABLE=test
 
 %:
 	dh $@ --with python2,python3 --buildsystem=pybuild


### PR DESCRIPTION
Debian rules has `DEB_BUILD_OPTIONS = nocheck`, but to disable tests in Python build we need to use  `PYBUILD_DISABLE`.

This has effect of closing QubesOS/qubes-issues#4365
