### PR TITLE
Switch from wget to curl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ VERSION := $(shell cat version)
 URL := https://files.pythonhosted.org/packages/source/x/xcffib/xcffib-$(VERSION).tar.gz
 SRC_FILE = $(notdir $(URL))
 UNTRUSTED_SUFF := .UNTRUSTED
-FETCH_CMD := wget --no-use-server-timestamps -q -O
 SHELL := /bin/bash
+
+ifeq ($(FETCH_CMD),)
+$(error "You can not run this Makefile without having FETCH_CMD defined")
+endif
 
 %: %.sha256
 	@$(FETCH_CMD) $@$(UNTRUSTED_SUFF) $(URL)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell cat version)
+VERSION := $(file <version)
 URL := https://files.pythonhosted.org/packages/source/x/xcffib/xcffib-$(VERSION).tar.gz
 SRC_FILE = $(notdir $(URL))
 UNTRUSTED_SUFF := .UNTRUSTED
@@ -10,7 +10,7 @@ endif
 
 %: %.sha256
 	@$(FETCH_CMD) $@$(UNTRUSTED_SUFF) $(URL)
-	@sha256sum --status -c <(printf "$$(cat $<)  -\n") <$@$(UNTRUSTED_SUFF) || \
+	@sha256sum --status -c <(printf "$(file <$<)  -\n") <$@$(UNTRUSTED_SUFF) || \
 		{ echo "Wrong SHA256 checksum on $@$(UNTRUSTED_SUFF)!"; exit 1; }
 	@mv $@$(UNTRUSTED_SUFF) $@
 


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.